### PR TITLE
add option to not report 4xx as errors for Grape

### DIFF
--- a/lib/ddtrace/contrib/grape/configuration/settings.rb
+++ b/lib/ddtrace/contrib/grape/configuration/settings.rb
@@ -18,6 +18,7 @@ module Datadog
 
           option :enabled, default: true
           option :service_name, default: Ext::SERVICE_NAME
+          option :error_for_4xx, default: true
         end
       end
     end

--- a/lib/ddtrace/contrib/grape/endpoint.rb
+++ b/lib/ddtrace/contrib/grape/endpoint.rb
@@ -86,7 +86,9 @@ module Datadog
               end
 
               # catch thrown exceptions
-              span.set_error(payload[:exception_object]) unless payload[:exception_object].nil?
+              if exception_is_error?(payload[:exception_object])
+                span.set_error(payload[:exception_object])
+              end
 
               # override the current span with this notification values
               span.set_tag(Ext::TAG_ROUTE_ENDPOINT, api_view) unless api_view.nil?
@@ -177,6 +179,10 @@ module Datadog
             datadog_configuration[:service_name]
           end
 
+          def error_for_4xx?
+            datadog_configuration[:error_for_4xx]
+          end
+
           def analytics_enabled?
             Contrib::Analytics.enabled?(datadog_configuration[:analytics_enabled])
           end
@@ -191,6 +197,16 @@ module Datadog
 
           def datadog_configuration
             Datadog.configuration[:grape]
+          end
+
+          def exception_is_error?(exception)
+            return false unless exception
+
+            if !error_for_4xx? && defined?(::Grape::Exceptions::Base) && exception.class < ::Grape::Exceptions::Base
+              status = exception.status
+            end
+
+            status.nil? || status > 499
           end
         end
       end

--- a/test/contrib/grape/request_test.rb
+++ b/test/contrib/grape/request_test.rb
@@ -60,6 +60,29 @@ class TracedAPITest < BaseAPITest
     assert_nil(run.parent)
   end
 
+  def test_traced_api_4xx_exception_report_no_error
+    Datadog.configure do |c|
+      c.use :grape, error_for_4xx: false
+    end
+    post '/base/hard_failure'
+
+    spans = @tracer.writer.spans()
+    render = spans[0]
+    assert_equal(render.status, 0)
+
+    Datadog.configure do |c|
+      c.use :grape, error_for_4xx: true
+    end
+  end
+
+  def test_mine_4xx_exception_report_error
+    post '/base/hard_failure'
+
+    spans = @tracer.writer.spans()
+    render = spans[0]
+    assert_equal(render.status, 1)
+  end
+
   def test_traced_api_before_after_filters
     # it should trace the endpoint body and all before/after filters
     get '/filtered/before_after'


### PR DESCRIPTION
Grape uses exceptions internally for 4xx errors. The DD agent reports these all as errors. This adds an option to not report those spans as errors. This is what the Rails integration does (and it is not configurable).